### PR TITLE
Setup Continuous Deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI - Build and Test Images
-on: [push, pull_request]
+
+on: [push]
 
 jobs:
   generate-matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
         # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action
-      - name: Set up QEMU
+      - name: Setup QEMU virtualization for multi-platform builds
         uses: docker/setup-qemu-action@v3
 
       - name: Build the Docker Images

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,7 @@ jobs:
 
       - name: Install Just so that justfile shortcuts are supported
         shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        run: sudo apt-get update && sudo apt-get install -y just
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Test Images
+name: CI - Build and Test Images
 on: [push, pull_request]
 
 jobs:
@@ -21,7 +21,6 @@ jobs:
         run: |
           pip install jq
           python scripts/generate_matrix.py
-
 
       - name: Verify matrix.json
         run: |
@@ -74,6 +73,7 @@ jobs:
         with:
           name: ${{ matrix.image }}_${{ matrix.image_version }}_${{ matrix.s6_architecture }}
           path: ${{ matrix.image }}_${{ matrix.image_version }}_${{ matrix.s6_architecture }}.tar
+          retention-days: 30
 
       - name: Print the Docker Images (for logging purposes)
         run: just list-local-image-architectures

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout the repository to the runner
         uses: actions/checkout@v4
 
+      - name: Install Just so that justfile shortcuts are supported
+        shell: bash
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y just
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,59 +1,37 @@
 name: Deploy Images to Docker Hub
 
 on:
-  repository_dispatch:
-    types: [my-event]
+  push:
+    branches:
+      - main
 
 jobs:
-  deploy:
+  build:
+    needs: generate-matrix
     runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout the repository to the runner
         uses: actions/checkout@v4
 
-      - name: Download artifacts info
-        uses: actions/download-artifact@v3
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
         with:
-          name: artifacts-info
-          path: .
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Parse artifacts info
-        id: parse
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+        # Add support for more platforms with QEMU.
+        # https://github.com/docker/setup-qemu-action
+      - name: Setup QEMU virtualization for multi-platform builds
+        uses: docker/setup-qemu-action@v3
+
+      - name: Build and push the Docker Images
         run: |
-          artifacts=$(jq -r '.artifacts' artifacts_info.json)
-          run_id=$(jq -r '.run_id' artifacts_info.json)
-          echo "Artifacts: $artifacts"
-          echo "Run ID: $run_id"
-          echo "::set-output name=artifacts::${artifacts}"
-          echo "::set-output name=run_id::${run_id}"
+          docker buildx create --use
+          ./scripts/run_parallel_builds.sh --push
 
-      - name: Install jq
-        run: sudo apt-get install -y jq
-
-      - name: Download all Docker image artifacts
-        run: |
-          artifacts="${{ steps.parse.outputs.artifacts }}"
-          run_id="${{ steps.parse.outputs.run_id }}"
-          echo "$artifacts" | tr ' ' '\n' | while read -r artifact; do
-            echo "Downloading $artifact"
-            artifact_id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/${{ github.repository }}/actions/runs/$run_id/artifacts | jq -r ".artifacts[] | select(.name==\"$artifact\") | .id")
-            gh api -H "Accept: application/vnd.github.v3+json" /repos/${{ github.repository }}/actions/artifacts/$artifact_id/archive -o ./images/$artifact.zip
-            unzip ./images/$artifact.zip -d ./images
-            rm ./images/$artifact.zip
-          done
-
-      # - name: Install Just so that justfile shortcuts are supported
-      #   shell: bash
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y just
-      #
-      # - name: Load Docker images from tarballs
-      #   run: |
-      #     for image_tar in ./images/*.tar; do
-      #       docker load -i "$image_tar"
-      #     done
-      #
-      # - name: Verify Docker images are available to be pushed
-      #   run: just list-local-image-architectures
+      - name: Verify remote image architectures using image manifests
+        run: just list-remote-image-architectures

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy Images to Docker Hub
+
+on:
+  repository_dispatch:
+    types: [my-event]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout the repository to the runner
+        uses: actions/checkout@v4
+
+      - name: Download artifacts info
+        uses: actions/download-artifact@v3
+        with:
+          name: artifacts-info
+          path: .
+
+      - name: Parse artifacts info
+        id: parse
+        run: |
+          artifacts=$(jq -r '.artifacts' artifacts_info.json)
+          run_id=$(jq -r '.run_id' artifacts_info.json)
+          echo "Artifacts: $artifacts"
+          echo "Run ID: $run_id"
+          echo "::set-output name=artifacts::${artifacts}"
+          echo "::set-output name=run_id::${run_id}"
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Download all Docker image artifacts
+        run: |
+          artifacts="${{ steps.parse.outputs.artifacts }}"
+          run_id="${{ steps.parse.outputs.run_id }}"
+          echo "$artifacts" | tr ' ' '\n' | while read -r artifact; do
+            echo "Downloading $artifact"
+            artifact_id=$(gh api -H "Accept: application/vnd.github.v3+json" /repos/${{ github.repository }}/actions/runs/$run_id/artifacts | jq -r ".artifacts[] | select(.name==\"$artifact\") | .id")
+            gh api -H "Accept: application/vnd.github.v3+json" /repos/${{ github.repository }}/actions/artifacts/$artifact_id/archive -o ./images/$artifact.zip
+            unzip ./images/$artifact.zip -d ./images
+            rm ./images/$artifact.zip
+          done
+
+      # - name: Install Just so that justfile shortcuts are supported
+      #   shell: bash
+      #   run: |
+      #     sudo apt-get update
+      #     sudo apt-get install -y just
+      #
+      # - name: Load Docker images from tarballs
+      #   run: |
+      #     for image_tar in ./images/*.tar; do
+      #       docker load -i "$image_tar"
+      #     done
+      #
+      # - name: Verify Docker images are available to be pushed
+      #   run: just list-local-image-architectures

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,9 +19,7 @@ jobs:
 
       - name: Install Just so that justfile shortcuts are supported
         shell: bash
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y just
+        run: sudo apt-get update && sudo apt-get install -y just
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout the repository to the runner
         uses: actions/checkout@v4
 
+      - name: Install Bash script dependencies
+        run: sudo apt-get update && sudo apt-get install -y parallel jq
+
       - name: Install Just so that justfile shortcuts are supported
         shell: bash
         run: |

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -103,7 +103,7 @@ parse_command_line_arguments() {
         break
         ;;
       *)
-        echo "Invalid option: $1"
+        echo "Invalid option: $1" >&2
         exit 1
         ;;
     esac

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -19,6 +19,7 @@ All of the following flags must be specified:
     -v|--image-version <image_version>                      The version of the official base image
     -a|--s6-overlay-architecture <s6_overlay_architecture>  The architecture of the s6 overlay tarball. See s6_architecture_mappings.json
     -s|--save                                               Save the built docker image as a tarball
+    -u|--push                                               Push the built docker image upstream
 
 Example using short flags:
     ${SCRIPT_NAME} -p linux/amd64 -i alpine -v 3.19 -a x86_64 --save
@@ -58,10 +59,11 @@ load_s6_overlay_version() {
 }
 
 parse_command_line_arguments() {
-  local short='p:i:v:a:sh'
-  local long='platform:,image:,image-version:,s6-overlay-architecture:,save,help'
+  local short='p:i:v:a:suh'
+  local long='platform:,image:,image-version:,s6-overlay-architecture:,save,push,help'
 
   SAVE='false'
+  PUSH='false'
 
   OPTIONS="$(getopt -o "$short" --long "$long" -- "$@")"
   eval set -- "$OPTIONS"
@@ -85,7 +87,11 @@ parse_command_line_arguments() {
         shift 2
         ;;
       -s | --save)
-        SAVE="true"
+        SAVE='true'
+        shift 1
+        ;;
+      -u | --push)
+        PUSH='true'
         shift 1
         ;;
       -h | --help)
@@ -110,14 +116,20 @@ build_image() {
   # Image tag example: webdavis/docker-s6-overlay:ubuntu-24.04-aarch64-3.1.6.2
   IMAGE_TAG="${REPO_ADDRESS}:${IMAGE}-${IMAGE_VERSION}-${S6_OVERLAY_ARCHITECTURE}-${S6_OVERLAY_VERSION}"
 
-  ${DOCKER_CMD} buildx build \
-    --load \
-    --platform "${DOCKER_PLATFORM}" \
-    --build-arg IMAGE_VERSION="${IMAGE_VERSION}" \
-    --build-arg S6_OVERLAY_VERSION="${S6_OVERLAY_VERSION}" \
-    --build-arg S6_OVERLAY_ARCHITECTURE="${S6_OVERLAY_ARCHITECTURE}" \
-    --tag "$IMAGE_TAG" \
-    -f "Dockerfile.$IMAGE" .
+  BUILD_CMD="${DOCKER_CMD} buildx build \
+      --load \
+      --platform \"${DOCKER_PLATFORM}\" \
+      --build-arg IMAGE_VERSION=\"${IMAGE_VERSION}\" \
+      --build-arg S6_OVERLAY_VERSION=\"${S6_OVERLAY_VERSION}\" \
+      --build-arg S6_OVERLAY_ARCHITECTURE=\"${S6_OVERLAY_ARCHITECTURE}\" \
+      --tag \"$IMAGE_TAG\" \
+      -f \"Dockerfile.$IMAGE\" ."
+
+  if [[ $PUSH == 'true' ]]; then
+    BUILD_CMD+=' --push'
+  fi
+
+  eval "$BUILD_CMD"
 }
 
 save_image() {

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -58,7 +58,7 @@ load_s6_overlay_version() {
 }
 
 parse_command_line_arguments() {
-  local short='p:i:v:a:hs'
+  local short='p:i:v:a:sh'
   local long='platform:,image:,image-version:,s6-overlay-architecture:,save,help'
 
   SAVE='false'

--- a/scripts/build_image.sh
+++ b/scripts/build_image.sh
@@ -22,10 +22,10 @@ All of the following flags must be specified:
     -u|--push                                               Push the built docker image upstream
 
 Example using short flags:
-    ${SCRIPT_NAME} -p linux/amd64 -i alpine -v 3.19 -a x86_64 --save
+    ${SCRIPT_NAME} -p linux/amd64 -i alpine -v 3.19 -a x86_64 -s -u
 
 Example using long flags:
-    ${SCRIPT_NAME} --platform linux/amd64 --image alpine --image-version 3.19 --s6-overlay-architecture x86_64 --save"
+    ${SCRIPT_NAME} --platform linux/amd64 --image alpine --image-version 3.19 --s6-overlay-architecture x86_64 --save --push"
 }
 
 verify_script_arguments() {

--- a/scripts/run_parallel_builds.sh
+++ b/scripts/run_parallel_builds.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+
+# Exit immediately if a command fails.
+set -eo pipefail
+
+OFFICIAL_IMAGE_METADATA='official_image_metadata.json'
+S6_ARCHITECTURE_MAPPINGS_FILE='s6_architecture_mappings.json'
+SCRIPT_NAME="${BASH_SOURCE##*/}"
+
+help() {
+    printf "%s\\n" "
+${SCRIPT_NAME}: A utility script that executes build_image.sh in parallel
+
+All of the following flags must be specified:
+
+    -u|--push   Push the built docker image upstream
+
+Example using short flags:
+    ${SCRIPT_NAME} -u
+
+Example using long flags:
+    ${SCRIPT_NAME} --push"
+}
+
+get_repo_root_directory() {
+  git rev-parse --show-toplevel
+}
+
+load_s6_architecture_mappings() {
+  declare -gA S6_ARCHITECTURE_MAPPINGS
+  declare -gA DOCKER_PLATFORM_MAPPINGS
+
+  while IFS="=" read -r key s6_overlay_architecture docker_platform; do
+    S6_ARCHITECTURE_MAPPINGS["$key"]="$s6_overlay_architecture"
+    DOCKER_PLATFORM_MAPPINGS["$key"]="$docker_platform"
+  done < <(jq -r 'to_entries | .[] | "\(.key)=\(.value.s6_architecture)=\(.value.docker_platform)"' "$S6_ARCHITECTURE_MAPPINGS_FILE")
+}
+
+parse_command_line_arguments() {
+  local short='uh'
+  local long='push,help'
+
+  PUSH='false'
+
+  OPTIONS="$(getopt -o "$short" --long "$long" -- "$@")"
+  eval set -- "$OPTIONS"
+
+  while true; do
+    case "$1" in
+      -u | --push)
+        PUSH='true'
+        shift 1
+        ;;
+      -h | --help)
+        help
+        exit 0
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        echo "Invalid option: $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+}
+
+process_images() {
+  jq -r '
+  . as $all |
+    keys[] as $image |
+    $all[$image][] |
+    [ $image, .version, (.architectures | join(" ")) ] |
+    @csv' "$OFFICIAL_IMAGE_METADATA" | while IFS=, read -r image image_version architectures; do
+      image=$(tr -d '"' <<< "$image")
+      image_version=$(tr -d '"' <<< "$image_version")
+      for arch in $architectures; do
+        arch=$(tr -d '"' <<< "$arch")
+        docker_platform=${DOCKER_PLATFORM_MAPPINGS[$arch]}
+        s6_overlay_architecture=${S6_ARCHITECTURE_MAPPINGS[$arch]}
+        echo "$docker_platform $image $image_version $s6_overlay_architecture"
+      done
+    done
+}
+
+build_images_in_parallel() {
+  if [[ $PUSH == 'true' ]]; then
+    process_images | parallel --colsep ' ' ./scripts/build_image.sh -p "{1}" -i "{2}" -v "{3}" -a "{4}" -u
+    return 0
+  fi
+
+  process_images | parallel --colsep ' ' ./scripts/build_image.sh -p "{1}" -i "{2}" -v "{3}" -a "{4}"
+}
+
+main() {
+  cd "$(get_repo_root_directory)" || exit 1
+  load_s6_architecture_mappings
+  build_images_in_parallel
+}
+
+main


### PR DESCRIPTION
This PR does the following:

- [x] Implements a `deploy.yml` GitHub Actions workflow that pushes images to Docker Hub.
- [x] Implements the `run_parallel_builds.sh` script to facilitate async `build_image.sh` execution (which proxies `docker buildx`).
- [x] Implements a `--push` flag in the `build_image.sh` Bash script.
- [x] Distinguishes between CI running on and **`push`** event, and CD running on any **`push`** event that is specifically to the `main` branch.